### PR TITLE
Remove arch from installer

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class ProtobufConan(ConanFile):
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt", "protobuf.patch"]
     generators = "cmake"
-    settings = "compiler", "arch", "os_build", "arch_build"
+    settings = "compiler", "os_build", "arch_build"
     short_paths = True
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
@@ -51,8 +51,6 @@ class ProtobufConan(ConanFile):
         cmake.install()
 
     def package_id(self):
-        self.info.settings.arch_build = self.info.settings.arch
-        del self.info.settings.arch
         del self.info.settings.compiler
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class ProtobufConan(ConanFile):
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt", "protobuf.patch"]
     generators = "cmake"
-    settings = "compiler", "os_build", "arch_build"
+    settings = "compiler", "arch", "os_build", "arch_build"
     short_paths = True
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
@@ -52,6 +52,7 @@ class ProtobufConan(ConanFile):
 
     def package_id(self):
         del self.info.settings.compiler
+        del self.info.settings.arch
 
     def package_info(self):
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools
 
 
 class TestPackageConan(ConanFile):
@@ -14,4 +14,5 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        self.run("protoc --version", run_environment=True)
+        if not tools.cross_building(self.settings):
+            self.run("protoc --version", run_environment=True)


### PR DESCRIPTION
- It's possible to force the arch_build by the compiler

Signed-off-by: Uilian Ries <uilianries@gmail.com>