### PR TITLE
Include arch_build and os_build in package id

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -53,6 +53,7 @@ class ProtobufConan(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
         del self.info.settings.arch
+        self.info.include_build_settings()
 
     def package_info(self):
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
This fixes a problem, when protoc_installer is used as dependency on armv7 as build system. Without this fix the executable for x86 is fetched as dependency, because os_build and arch_build setting are removed by default from the package id: https://docs.conan.io/en/latest/reference/conanfile/methods.html#self-info-discard-build-settings-self-info-include-build-settings